### PR TITLE
Add 'repositories' setting for Maven Central.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+repositories {
+    mavenCentral()
+}
+
 allprojects {
     group 'com.ka'
     version '0.0.1-SNAPSHOT'


### PR DESCRIPTION
I'm no Gradle expert, but when I attempted to build this project, I received an error : 

```shell
laptop:ExcelCompare me$ gradle distZip
:compileJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Could not resolve all dependencies for configuration ':compileClasspath'.
> Cannot resolve external dependency org.apache.poi:poi-ooxml:3.12 because no repositories are defined.
  Required by:
      project :
> Cannot resolve external dependency org.apache.odftoolkit:simple-odf:0.8.1-incubating because no repositories are defined.
  Required by:
      project :
> Cannot resolve external dependency com.google.code.findbugs:jsr305:3.0.1 because no repositories are defined.
  Required by:
      project :

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 0.722 secs
```
My environment includes the following :
```shell
------------------------------------------------------------
Gradle 3.5
------------------------------------------------------------

Build time:   2017-04-10 13:37:25 UTC
Revision:     b762622a185d59ce0cfc9cbc6ab5dd22469e18a6

Groovy:       2.4.10
Ant:          Apache Ant(TM) version 1.9.6 compiled on June 29 2015
JVM:          1.8.0_121
```

If I modify `build.gradle` just slightly (see diff) the build succeeds.  Is my version correct or perhaps there is a dotfile that should be modified instead?  If instead, this should be controlled by a dotfile, should we add some description to your upstream project PR (https://github.com/na-ka-na/ExcelCompare/pull/34) ?

Hope this helps, and thanks for your work 👍 